### PR TITLE
Specify rubygems explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'node'


### PR DESCRIPTION
New bundler requires you to explicitly specify rubygems.org as the source
